### PR TITLE
Add "style" field to package.json for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cssgram",
   "version": "0.1.2",
+  "style": "source/css/cssgram.css",
   "dependencies": {},
   "author": {
     "name": "Una Kravets",


### PR DESCRIPTION
This adds the all-in-one file as the main entry point under "style", the de facto field for css bundlers. This way, the module can be referenced as `@import 'cssgram'` in bundlers like like [postcss-import](https://github.com/postcss/postcss-import), [sheetify](https://github.com/sheetify/sheetify), and others.

Of course, the individual filters can still by required through `@import 'cssgram/source/css/filter-name.css`.