### PR TITLE
Add pointer-events: none; to _shared.scss

### DIFF
--- a/source/scss/_shared.scss
+++ b/source/scss/_shared.scss
@@ -8,5 +8,6 @@
     width: 100%;
     top: 0; left: 0;
     position: absolute;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
Keeps the ::after psuedo-element from blocking hovering/clicking on any content being filtered.

Example: YouTube video filtered with CSSgram

http://codepen.io/bennettfeely/pen/eprWzW?editors=010