### PR TITLE
add eyeglass module configuration

### DIFF
--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function(eyeglass, sass) {
+  console.log( "hey!" );
+  return {
+    sassDir: require("path").resolve(__dirname, "source/scss")
+  };
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "cssgram",
   "version": "0.1.2",
   "style": "source/css/cssgram.css",
-  "dependencies": {},
+  "dependencies": {
+    "path": "^0.12.7"
+  },
   "author": {
     "name": "Una Kravets",
     "email": "una.kravets@gmail.com",
@@ -16,8 +18,13 @@
     "CSS",
     "library",
     "photo",
-    "effects"
+    "effects",
+    "eyeglass-module"
   ],
+  "eyeglass": {
+    "needs": "^0.6.5",
+    "exports": "eyeglass-exports.js"
+  },
   "devDependencies": {
     "browser-sync": "^2.0.0-rc4",
     "gulp": "^3.8.10",


### PR DESCRIPTION
OK, I got this working, but there's a hitch. The output is way bigger than it needs to be: [this](https://gist.github.com/xiwcx/4225f86907f531c922b7#file-main-scss) gets compiled in to [this](https://gist.github.com/xiwcx/4225f86907f531c922b7#file-main-css).

Testing instructions:

- get an eyeglass build going
- pull this branch
- use `npm link` to test an unregistered npm module
- see some output that is less than ideal

@chriseppstein do you have a recommendation here? is there a way to exclude files from eyeglass seeing them (does it honor underscores)? is there a way to aim eyeglass at a single file or should the sass files get cleaned up in a way that doesn't duplicate the output so much?

@una down to work through this together on slack. maybe the sass foundation will spring for fancy slack so we can use screenhero...