### PR TITLE
re-added slumber

### DIFF
--- a/source/scss/cssgram.scss
+++ b/source/scss/cssgram.scss
@@ -19,3 +19,4 @@
 @import 'clarendon';
 @import 'willow';
 @import 'rise';
+@import 'slumber';

--- a/source/scss/slumber.scss
+++ b/source/scss/slumber.scss
@@ -1,0 +1,22 @@
+/*
+ *
+ * Slumber
+ *
+ */
+@import 'shared';
+
+%slumber,
+.slumber {
+  @extend %filter-base;
+  filter: saturate(.66) brightness(1.05);
+
+  &::after {
+    background: rgba(125, 105, 24, 0.5);
+    mix-blend-mode: soft-light;
+  }
+
+  &::before {
+    background: rgba(69, 41, 12, .4);
+    mix-blend-mode: lighten;
+  }
+}


### PR DESCRIPTION

I modified the filter a bit. What do you think?
![slumber-sample](https://cloud.githubusercontent.com/assets/9392701/12536906/2d8c6c4c-c2bb-11e5-842b-1d8d1929213b.png)

Also, about the test twig file, I figured the line 38 of site/test/index.twig

>            <figure class="{{f.name}}">

Shouldn't it be

>            <figure class="{{f.usage}}">

instead so the figures get the class name in lowercase instead of capitalized? (e.g 'slumber' instead of 'Slumber')