### PR TITLE
Make this library (SASS source) extensible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you use custom naming in your CSS architecture, you can add the `.scss` files
 
 1. [Download the `scss/` folder contents](https://github.com/una/CSSgram/tree/master/source/scss)
 * Include a link to `scss/cssgram.scss` via an `@import` statement in your Sass manifest file (i.e. `main.scss`). It may look like: `@import 'vendor/cssgram'`
-* Extend the placeholder selector (e.g. `@extend %aden`) in your element.
+* Extend the placeholder selector (e.g. `@extend %aden` or using mixins `@include aden()`) in your element.
 
 For example:
 
@@ -92,11 +92,27 @@ For example:
 }
 ```
 
+or using mixins (more flexible)
+
+```
+// Sass (without adding new CSS3 filters)
+.viz--beautiful {
+  @include aden();
+}
+
+// Sass (adding new CSS3 filters)
+.viz--beautiful {
+  @include aden(blur(2px) /*...*/);
+}
+```
+
 Alternatively, you can just download and link any individual `.scss` file in your Sass manifest (i.e. `scss/aden.scss`), if you're just using one of the styles.
 
 ### Available Placeholders
 
 _For use in Sass stylesheets:_
+
+**Extends**
 
 *   Aden: `@extend %aden`
 *   Reyes: `@extend %reyes`
@@ -116,6 +132,27 @@ _For use in Sass stylesheets:_
 *   Moon: `@extend %moon`
 *   Clarendon: `@extend %clarendon`
 *   Willow: `@extend %willow`
+
+**Mixins** (You can add more CSS3 filters as arguments)
+
+*   Aden: `@include aden()`
+*   Reyes: `@include reyes()`
+*   Perpetua: `@include perpetua()`
+*   Inkwell: `@include inkwell()`
+*   Toaster: `@include toaster()`
+*   Walden: `@include walden()`
+*   Hudson: `@include hudson()`
+*   Gingham: `@include gingham()`
+*   Mayfair: `@include mayfair()`
+*   Lo-fi: `@include lofi()`
+*   X-Pro II: `@include xpro2()`
+*   1977: `@include _1977()`
+*   Brooklyn: `@include brooklyn()`
+*   Nashville: `@include nashville()`
+*   Lark: `@include lark()`
+*   Moon: `@include moon()`
+*   Clarendon: `@include clarendon()`
+*   Willow: `@include willow()`
 
 ## Contributing
 

--- a/site/index.html
+++ b/site/index.html
@@ -1,26 +1,33 @@
-
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>CSSGram</title>
   <meta name="viewport" content="initial-scale=1, maximum-scale=1">
 
-    <link rel="stylesheet" href="css/demo-site.min.css">
+  <link rel="stylesheet" href="css/demo-site.min.css">
 
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    (function(i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r;
+      i[r] = i[r] || function() {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date();
+      a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
     ga('create', 'UA-36758177-8', 'auto');
     ga('send', 'pageview');
-
   </script>
 </head>
+
 <body class="home">
-    <section class="title-section">
+  <section class="title-section">
     <img class="title--logo" src="img/cssgram-logo.svg" alt="CSSgram">
     <h2 class="title--top-sub">A tiny (&lt;1kb gzipped!) library for recreating <a href="http://instagram.com">Instagram</a> filters with CSS filters and blend modes.</h2>
   </section>
@@ -29,12 +36,12 @@
     <div class="demo__input-area">
       <fieldset class="demo__option-field">
         <legend>Choose a sample image:</legend>
-                  <img class="demo__option-img" src="img/atx.jpg" alt="atx image">
-                <img class="demo__option-img" src="img/bike.jpg" alt="bike image">
-                <img class="demo__option-img" src="img/cacti.jpg" alt="cacti image">
-                <img class="demo__option-img" src="img/lakegeneva.jpg" alt="lakegeneva image">
-                <img class="demo__option-img" src="img/tahoe.jpg" alt="tahoe image">
-              <br>
+        <img class="demo__option-img" src="img/atx.jpg" alt="atx image">
+        <img class="demo__option-img" src="img/bike.jpg" alt="bike image">
+        <img class="demo__option-img" src="img/cacti.jpg" alt="cacti image">
+        <img class="demo__option-img" src="img/lakegeneva.jpg" alt="lakegeneva image">
+        <img class="demo__option-img" src="img/tahoe.jpg" alt="tahoe image">
+        <br>
         <label class="demo__input-label">
           Or paste in a link to your own photo:
           <input class="demo__input-img" type="text">
@@ -50,133 +57,133 @@
           <figcaption>#nofilter</figcaption>
         </figure>
       </li>
-                        <li class="demo__item">
-            <figure class="_1977">
-              <img>
-              <figcaption>1977</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="aden">
-              <img>
-              <figcaption>Aden</figcaption>
-            </figure>
-          </li>
-                                                                          <li class="demo__item">
-            <figure class="brooklyn">
-              <img>
-              <figcaption>Brooklyn</figcaption>
-            </figure>
-          </li>
-                                              <li class="demo__item">
-            <figure class="clarendon">
-              <img>
-              <figcaption>Clarendon</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="earlybird">
-              <img>
-              <figcaption>Earlybird</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="gingham">
-              <img>
-              <figcaption>Gingham</figcaption>
-            </figure>
-          </li>
-                                                                          <li class="demo__item">
-            <figure class="hudson">
-              <img>
-              <figcaption>Hudson</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="inkwell">
-              <img>
-              <figcaption>Inkwell</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="lark">
-              <img>
-              <figcaption>Lark</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="lofi">
-              <img>
-              <figcaption>Lo-Fi</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="mayfair">
-              <img>
-              <figcaption>Mayfair</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="moon">
-              <img>
-              <figcaption>Moon</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="nashville">
-              <img>
-              <figcaption>Nashville</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="perpetua">
-              <img>
-              <figcaption>Perpetua</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="reyes">
-              <img>
-              <figcaption>Reyes</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="rise">
-              <img>
-              <figcaption>Rise</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="slumber">
-              <img>
-              <figcaption>Slumber</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="toaster">
-              <img>
-              <figcaption>Toaster</figcaption>
-            </figure>
-          </li>
-                                                            <li class="demo__item">
-            <figure class="walden">
-              <img>
-              <figcaption>Walden</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="willow">
-              <img>
-              <figcaption>Willow</figcaption>
-            </figure>
-          </li>
-                                <li class="demo__item">
-            <figure class="xpro2">
-              <img>
-              <figcaption>X-pro II</figcaption>
-            </figure>
-          </li>
-                  </ul>
+      <li class="demo__item">
+        <figure class="_1977">
+          <img>
+          <figcaption>1977</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="aden">
+          <img>
+          <figcaption>Aden</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="brooklyn">
+          <img>
+          <figcaption>Brooklyn</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="clarendon">
+          <img>
+          <figcaption>Clarendon</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="earlybird">
+          <img>
+          <figcaption>Earlybird</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="gingham">
+          <img>
+          <figcaption>Gingham</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="hudson">
+          <img>
+          <figcaption>Hudson</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="inkwell">
+          <img>
+          <figcaption>Inkwell</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="lark">
+          <img>
+          <figcaption>Lark</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="lofi">
+          <img>
+          <figcaption>Lo-Fi</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="mayfair">
+          <img>
+          <figcaption>Mayfair</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="moon">
+          <img>
+          <figcaption>Moon</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="nashville">
+          <img>
+          <figcaption>Nashville</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="perpetua">
+          <img>
+          <figcaption>Perpetua</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="reyes">
+          <img>
+          <figcaption>Reyes</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="rise">
+          <img>
+          <figcaption>Rise</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="slumber">
+          <img>
+          <figcaption>Slumber</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="toaster">
+          <img>
+          <figcaption>Toaster</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="walden">
+          <img>
+          <figcaption>Walden</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="willow">
+          <img>
+          <figcaption>Willow</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="xpro2">
+          <img>
+          <figcaption>X-pro II</figcaption>
+        </figure>
+      </li>
+    </ul>
   </section>
 
   <section class="explanation-section">
@@ -184,9 +191,11 @@
 
     <p><strong class="callout">For more background on CSS Image Effects, you can check out my blog series <a href="http://una.im">here</a>, or watch my <a href="https://www.youtube.com/watch?v=LY65F2e4B5w">video</a> from CSS Conf EU, which gives a baseline on blend modes and filters.</strong></p>
 
-    <p>Simply put, CSSgram is a library for editing your images with Instagram-like filters directly in CSS. What we're doing here is adding filters to the images as well as applying color and/or gradient overlays via various blending techniques to mimic these effects. This means <em>less manual image processing</em> and more fun filter effects on the web!</p>
+    <p>Simply put, CSSgram is a library for editing your images with Instagram-like filters directly in CSS. What we're doing here is adding filters to the images as well as applying color and/or gradient overlays via various blending techniques to mimic
+      these effects. This means <em>less manual image processing</em> and more fun filter effects on the web!</p>
 
-    <p>We are using pseudo-elements (i.e. <code>:before</code> and <code>:after</code>) to create the filter effects, so you must apply these filters on a containing element (i.e. not a content-block like <code>&lt;img&gt;</code>. The recommendation is to wrap your images in a <code>&lt;figure&gt;</code> tag. More about the tag <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure">here.</a></p>
+    <p>We are using pseudo-elements (i.e. <code>:before</code> and <code>:after</code>) to create the filter effects, so you must apply these filters on a containing element (i.e. not a content-block like <code>&lt;img&gt;</code>. The recommendation is to
+      wrap your images in a <code>&lt;figure&gt;</code> tag. More about the tag <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure">here.</a></p>
 
     <h3>Browser Support</h3>
 
@@ -201,7 +210,7 @@
     </ul>
 
     <p>For more information, check on <a href="http://caniuse.com/">Can I Use</a>.</p>
-  <hr>
+    <hr>
   </section>
 
   <section class="how-to-section">
@@ -213,13 +222,15 @@
 
     <p>When using CSS classes, you can simply add the class with the filter name to the element containing your image.</p>
 
-    <p><strong>The quickest way to do this is to link to our CDN</strong> in your <code>&lt;head&gt;</code> tag: <code>&lt;link rel="stylesheet" href="https://cssgram-cssgram.netdna-ssl.com/cssgram.min.css"&gt;</code>. Then, add a class to your figure element with the name of the filter you would like to use (shown below)</p>
+    <p><strong>The quickest way to do this is to link to our CDN</strong> in your <code>&lt;head&gt;</code> tag: <code>&lt;link rel="stylesheet" href="https://cssgram-cssgram.netdna-ssl.com/cssgram.min.css"&gt;</code>. Then, add a class to your figure element
+      with the name of the filter you would like to use (shown below)</p>
 
     <p>If you want to work locally, do the following:</p>
 
     <ol>
       <li><a href="https://raw.githubusercontent.com/una/CSSgram/master/source/css/cssgram.min.css" download>Download the CSSgram Library</a></li>
-      <li>Link to the CSSgram library within your project: <br><code>&lt;link rel="stylesheet" href="css/vendor/cssgram.min.css"&gt;</code></li>
+      <li>Link to the CSSgram library within your project:
+        <br><code>&lt;link rel="stylesheet" href="css/vendor/cssgram.min.css"&gt;</code></li>
       <li>Add a class to your figure element with the name of the filter you would like to use</li>
     </ol>
 
@@ -237,39 +248,40 @@
     <h3>Available Classes</h3>
     <small><em>For use in HTML markup:</em></small>
     <ul class="available-classes">
-                        <li>1977: <code>class="_1977"</code></li>
-                                <li>Aden: <code>class="aden"</code></li>
-                                                                          <li>Brooklyn: <code>class="brooklyn"</code></li>
-                                              <li>Clarendon: <code>class="clarendon"</code></li>
-                                                            <li>Earlybird: <code>class="earlybird"</code></li>
-                                <li>Gingham: <code>class="gingham"</code></li>
-                                                                          <li>Hudson: <code>class="hudson"</code></li>
-                                <li>Inkwell: <code>class="inkwell"</code></li>
-                                                            <li>Lark: <code>class="lark"</code></li>
-                                <li>Lo-Fi: <code>class="lofi"</code></li>
-                                                            <li>Mayfair: <code>class="mayfair"</code></li>
-                                <li>Moon: <code>class="moon"</code></li>
-                                <li>Nashville: <code>class="nashville"</code></li>
-                                <li>Perpetua: <code>class="perpetua"</code></li>
-                                <li>Reyes: <code>class="reyes"</code></li>
-                                <li>Rise: <code>class="rise"</code></li>
-                                                            <li>Slumber: <code>class="slumber"</code></li>
-                                                            <li>Toaster: <code>class="toaster"</code></li>
-                                                            <li>Walden: <code>class="walden"</code></li>
-                                <li>Willow: <code>class="willow"</code></li>
-                                <li>X-pro II: <code>class="xpro2"</code></li>
-                  </ul>
+      <li>1977: <code>class="_1977"</code></li>
+      <li>Aden: <code>class="aden"</code></li>
+      <li>Brooklyn: <code>class="brooklyn"</code></li>
+      <li>Clarendon: <code>class="clarendon"</code></li>
+      <li>Earlybird: <code>class="earlybird"</code></li>
+      <li>Gingham: <code>class="gingham"</code></li>
+      <li>Hudson: <code>class="hudson"</code></li>
+      <li>Inkwell: <code>class="inkwell"</code></li>
+      <li>Lark: <code>class="lark"</code></li>
+      <li>Lo-Fi: <code>class="lofi"</code></li>
+      <li>Mayfair: <code>class="mayfair"</code></li>
+      <li>Moon: <code>class="moon"</code></li>
+      <li>Nashville: <code>class="nashville"</code></li>
+      <li>Perpetua: <code>class="perpetua"</code></li>
+      <li>Reyes: <code>class="reyes"</code></li>
+      <li>Rise: <code>class="rise"</code></li>
+      <li>Slumber: <code>class="slumber"</code></li>
+      <li>Toaster: <code>class="toaster"</code></li>
+      <li>Walden: <code>class="walden"</code></li>
+      <li>Willow: <code>class="willow"</code></li>
+      <li>X-pro II: <code>class="xpro2"</code></li>
+    </ul>
 
     <hr>
 
     <h3>Use Sass <code>@extends</code></h3>
 
-    <p>If you use custom naming in your CSS architecture, you can add the .scss files for the provided styles within your project and then <code>@extend</code> the filter effects within your style definitions. If you think extends are stupid, I will fight you 😊.</p>
+    <p>If you use custom naming in your CSS architecture, you can add the .scss files for the provided styles within your project and then <code>@extend</code> the filter effects within your style definitions. If you think extends are stupid, I will fight
+      you 😊.</p>
 
     <ol>
       <li><a href="https://github.com/una/CSSgram/tree/master/source/scss" download>Download the /scss folder contents</a></li>
       <li>Include a link to <code>scss/cssgram.scss</code> via an import statement in your Sass manifest file (i.e. <code>main.scss</code>). It may look like: <code>@import 'vendor/cssgram';</code></li>
-      <li>Extend the silent placeholder selector <code>@extend %aden;</code> in your element.</li>
+      <li>Extend the silent placeholder selector <code>@extend %aden;</code> (or using mixins <code>@include aden();</code>) in your element.</li>
     </ol>
 
     <p>For example:</p>
@@ -288,43 +300,448 @@
       }
     </code></pre>
 
+    <small>or using mixins (more flexible)</small>
+
+    <pre><code>
+      <span class="comment">// Sass (without adding new CSS3 filters)</span>
+      <span class="highlight">.viz--beautiful</span> {
+        @include aden();
+      }
+      <span class="comment">// Sass (adding new CSS3 filters)</span>
+      <span class="highlight">.viz--beautiful</span> {
+        @include aden(blur(2px) /*...*/);
+      }
+    </code></pre>
+
     <small>Alternatively, you can just download and link any individual .scss file in your Sass manifest: <br> (i.e. <code>scss/aden.scss</code>), if you're just using one of the styles.</li></small>
 
     <h3>Available Extends</h3>
     <small><em>For use in Sass elements:</em></small>
     <ul class="available-classes">
-                        <li>1977: <code>@extend %_1977;</code></li>
-                                <li>Aden: <code>@extend %aden;</code></li>
-                                                                          <li>Brooklyn: <code>@extend %brooklyn;</code></li>
-                                              <li>Clarendon: <code>@extend %clarendon;</code></li>
-                                                            <li>Earlybird: <code>@extend %earlybird;</code></li>
-                                <li>Gingham: <code>@extend %gingham;</code></li>
-                                                                          <li>Hudson: <code>@extend %hudson;</code></li>
-                                <li>Inkwell: <code>@extend %inkwell;</code></li>
-                                                            <li>Lark: <code>@extend %lark;</code></li>
-                                <li>Lo-Fi: <code>@extend %lofi;</code></li>
-                                                            <li>Mayfair: <code>@extend %mayfair;</code></li>
-                                <li>Moon: <code>@extend %moon;</code></li>
-                                <li>Nashville: <code>@extend %nashville;</code></li>
-                                <li>Perpetua: <code>@extend %perpetua;</code></li>
-                                <li>Reyes: <code>@extend %reyes;</code></li>
-                                <li>Rise: <code>@extend %rise;</code></li>
-                                                            <li>Slumber: <code>@extend %slumber;</code></li>
-                                                            <li>Toaster: <code>@extend %toaster;</code></li>
-                                                            <li>Walden: <code>@extend %walden;</code></li>
-                                <li>Willow: <code>@extend %willow;</code></li>
-                                <li>X-pro II: <code>@extend %xpro2;</code></li>
-                  </ul>
-  <hr>
+      <li>1977: <code>@extend %_1977;</code></li>
+      <li>Aden: <code>@extend %aden;</code></li>
+      <li>Brooklyn: <code>@extend %brooklyn;</code></li>
+      <li>Clarendon: <code>@extend %clarendon;</code></li>
+      <li>Earlybird: <code>@extend %earlybird;</code></li>
+      <li>Gingham: <code>@extend %gingham;</code></li>
+      <li>Hudson: <code>@extend %hudson;</code></li>
+      <li>Inkwell: <code>@extend %inkwell;</code></li>
+      <li>Lark: <code>@extend %lark;</code></li>
+      <li>Lo-Fi: <code>@extend %lofi;</code></li>
+      <li>Mayfair: <code>@extend %mayfair;</code></li>
+      <li>Moon: <code>@extend %moon;</code></li>
+      <li>Nashville: <code>@extend %nashville;</code></li>
+      <li>Perpetua: <code>@extend %perpetua;</code></li>
+      <li>Reyes: <code>@extend %reyes;</code></li>
+      <li>Rise: <code>@extend %rise;</code></li>
+      <li>Slumber: <code>@extend %slumber;</code></li>
+      <li>Toaster: <code>@extend %toaster;</code></li>
+      <li>Walden: <code>@extend %walden;</code></li>
+      <li>Willow: <code>@extend %willow;</code></li>
+      <li>X-pro II: <code>@extend %xpro2;</code></li>
+    </ul>
+    <hr>
   </section>
   <footer class="attribution">Made with love by <a href="http://twitter.com/una">Una</a> | <a href="http://github.com/una/CSSgram">View Source</a></footer>
 
-    <script>
+  <script>
     var inputField = document.querySelector(".demo__input-img")
+
     function pickSample(img) {
       updateImages(img.src)
       inputField.value = img.getAttribute("src")
     }
+
+    function updateImages(src) {
+      var imgs = document.querySelectorAll(".demo__item img")
+      for (var i = 0; i < imgs.length; i++) imgs[i].src = src
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>CSSGram</title>
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+
+  <link rel="stylesheet" href="css/demo-site.min.css">
+
+  <script>
+    (function(i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r;
+      i[r] = i[r] || function() {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date();
+      a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+    ga('create', 'UA-36758177-8', 'auto');
+    ga('send', 'pageview');
+  </script>
+</head>
+
+<body class="home">
+  <section class="title-section">
+    <img class="title--logo" src="img/cssgram-logo.svg" alt="CSSgram">
+    <h2 class="title--top-sub">A tiny (&lt;1kb gzipped!) library for recreating <a href="http://instagram.com">Instagram</a> filters with CSS filters and blend modes.</h2>
+  </section>
+
+  <section class="demo__section">
+    <div class="demo__input-area">
+      <fieldset class="demo__option-field">
+        <legend>Choose a sample image:</legend>
+        <img class="demo__option-img" src="img/atx.jpg" alt="atx image">
+        <img class="demo__option-img" src="img/bike.jpg" alt="bike image">
+        <img class="demo__option-img" src="img/cacti.jpg" alt="cacti image">
+        <img class="demo__option-img" src="img/lakegeneva.jpg" alt="lakegeneva image">
+        <img class="demo__option-img" src="img/tahoe.jpg" alt="tahoe image">
+        <br>
+        <label class="demo__input-label">
+          Or paste in a link to your own photo:
+          <input class="demo__input-img" type="text">
+        </label>
+      </fieldset>
+
+      <small class="demo__note">Hovering over any of these images (or clicking on mobile) will remove the filter effect to visualize the changes.</small>
+    </div>
+    <ul class="demo__list">
+      <li class="demo__item">
+        <figure>
+          <img>
+          <figcaption>#nofilter</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="_1977">
+          <img>
+          <figcaption>1977</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="aden">
+          <img>
+          <figcaption>Aden</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="brooklyn">
+          <img>
+          <figcaption>Brooklyn</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="clarendon">
+          <img>
+          <figcaption>Clarendon</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="earlybird">
+          <img>
+          <figcaption>Earlybird</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="gingham">
+          <img>
+          <figcaption>Gingham</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="hudson">
+          <img>
+          <figcaption>Hudson</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="inkwell">
+          <img>
+          <figcaption>Inkwell</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="lark">
+          <img>
+          <figcaption>Lark</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="lofi">
+          <img>
+          <figcaption>Lo-Fi</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="mayfair">
+          <img>
+          <figcaption>Mayfair</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="moon">
+          <img>
+          <figcaption>Moon</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="nashville">
+          <img>
+          <figcaption>Nashville</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="perpetua">
+          <img>
+          <figcaption>Perpetua</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="reyes">
+          <img>
+          <figcaption>Reyes</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="rise">
+          <img>
+          <figcaption>Rise</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="slumber">
+          <img>
+          <figcaption>Slumber</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="toaster">
+          <img>
+          <figcaption>Toaster</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="walden">
+          <img>
+          <figcaption>Walden</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="willow">
+          <img>
+          <figcaption>Willow</figcaption>
+        </figure>
+      </li>
+      <li class="demo__item">
+        <figure class="xpro2">
+          <img>
+          <figcaption>X-pro II</figcaption>
+        </figure>
+      </li>
+    </ul>
+  </section>
+
+  <section class="explanation-section">
+    <h2>What is This?</h2>
+
+    <p><strong class="callout">For more background on CSS Image Effects, you can check out my blog series <a href="http://una.im">here</a>, or watch my <a href="https://www.youtube.com/watch?v=LY65F2e4B5w">video</a> from CSS Conf EU, which gives a baseline on blend modes and filters.</strong></p>
+
+    <p>Simply put, CSSgram is a library for editing your images with Instagram-like filters directly in CSS. What we're doing here is adding filters to the images as well as applying color and/or gradient overlays via various blending techniques to mimic
+      these effects. This means <em>less manual image processing</em> and more fun filter effects on the web!</p>
+
+    <p>We are using pseudo-elements (i.e. <code>:before</code> and <code>:after</code>) to create the filter effects, so you must apply these filters on a containing element (i.e. not a content-block like <code>&lt;img&gt;</code>. The recommendation is to
+      wrap your images in a <code>&lt;figure&gt;</code> tag. More about the tag <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure">here.</a></p>
+
+    <h3>Browser Support</h3>
+
+    <p>This library uses <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/filter">CSS Filters</a> and <a href="https://css-tricks.com/basics-css-blend-modes/">CSS Blend Modes</a>. This features are supported in the following browsers:</p>
+
+    <ul class="supported-browsers">
+      <li class="supported">Google Chrome: 43+</li>
+      <li class="supported">Mozilla Firefox: 38+</li>
+      <li class="not-supported">Internet Explorer: Nope</li>
+      <li class="supported">Opera: 32+</li>
+      <li class="supported">Safari: 8+</li>
+    </ul>
+
+    <p>For more information, check on <a href="http://caniuse.com/">Can I Use</a>.</p>
+    <hr>
+  </section>
+
+  <section class="how-to-section">
+    <h2>Usage</h2>
+
+    <p><strong>There are currently 2 ways to consume this library:</strong></p>
+
+    <h3 id="use-css-classes">Use CSS classes</h3>
+
+    <p>When using CSS classes, you can simply add the class with the filter name to the element containing your image.</p>
+
+    <p><strong>The quickest way to do this is to link to our CDN</strong> in your <code>&lt;head&gt;</code> tag: <code>&lt;link rel="stylesheet" href="https://cssgram-cssgram.netdna-ssl.com/cssgram.min.css"&gt;</code>. Then, add a class to your figure element
+      with the name of the filter you would like to use (shown below)</p>
+
+    <p>If you want to work locally, do the following:</p>
+
+    <ol>
+      <li><a href="https://raw.githubusercontent.com/una/CSSgram/master/source/css/cssgram.min.css" download>Download the CSSgram Library</a></li>
+      <li>Link to the CSSgram library within your project:
+        <br><code>&lt;link rel="stylesheet" href="css/vendor/cssgram.min.css"&gt;</code></li>
+      <li>Add a class to your figure element with the name of the filter you would like to use</li>
+    </ol>
+
+    <p>For example:</p>
+
+    <pre><code>
+      <span class="comment">&lt;!-- HTML --&gt;</span>
+      &lt;figure <span class="highlight">class="aden"</span>&gt;
+        &lt;img src="../img.png"&gt;
+      &lt;/figure&gt;
+    </code></pre>
+
+    <small>Alternatively, you can just download and link to any individual css file: <br> <code>&lt;link rel="stylesheet" href="css/vendor/aden.min.css"&gt;</code>, if you're just using one of the styles.</li></small>
+
+    <h3>Available Classes</h3>
+    <small><em>For use in HTML markup:</em></small>
+    <ul class="available-classes">
+      <li>1977: <code>class="_1977"</code></li>
+      <li>Aden: <code>class="aden"</code></li>
+      <li>Brooklyn: <code>class="brooklyn"</code></li>
+      <li>Clarendon: <code>class="clarendon"</code></li>
+      <li>Earlybird: <code>class="earlybird"</code></li>
+      <li>Gingham: <code>class="gingham"</code></li>
+      <li>Hudson: <code>class="hudson"</code></li>
+      <li>Inkwell: <code>class="inkwell"</code></li>
+      <li>Lark: <code>class="lark"</code></li>
+      <li>Lo-Fi: <code>class="lofi"</code></li>
+      <li>Mayfair: <code>class="mayfair"</code></li>
+      <li>Moon: <code>class="moon"</code></li>
+      <li>Nashville: <code>class="nashville"</code></li>
+      <li>Perpetua: <code>class="perpetua"</code></li>
+      <li>Reyes: <code>class="reyes"</code></li>
+      <li>Rise: <code>class="rise"</code></li>
+      <li>Slumber: <code>class="slumber"</code></li>
+      <li>Toaster: <code>class="toaster"</code></li>
+      <li>Walden: <code>class="walden"</code></li>
+      <li>Willow: <code>class="willow"</code></li>
+      <li>X-pro II: <code>class="xpro2"</code></li>
+    </ul>
+
+    <hr>
+
+    <h3>Use Sass <code>@extends</code></h3>
+
+    <p>If you use custom naming in your CSS architecture, you can add the .scss files for the provided styles within your project and then <code>@extend</code> the filter effects within your style definitions. If you think extends are stupid, I will fight
+      you 😊.</p>
+
+    <ol>
+      <li><a href="https://github.com/una/CSSgram/tree/master/source/scss" download>Download the /scss folder contents</a></li>
+      <li>Include a link to <code>scss/cssgram.scss</code> via an import statement in your Sass manifest file (i.e. <code>main.scss</code>). It may look like: <code>@import 'vendor/cssgram';</code></li>
+      <li>Extend the silent placeholder selector <code>@extend %aden;</code> (or using mixins <code>@include aden();</code>) in your element.</li>
+    </ol>
+
+    <p>For example:</p>
+
+    <pre><code>
+      <span class="comment">&lt;!-- HTML --&gt;</span>
+      &lt;figure class=<span class="highlight">"viz--beautiful"</span>&gt;
+        &lt;img src="../img.png"&gt;
+      &lt;/figure&gt;
+    </code></pre>
+
+    <pre><code>
+      <span class="comment">// Sass</span>
+      <span class="highlight">.viz--beautiful</span> {
+        @extend %aden;
+      }
+    </code></pre>
+
+    <small>or using mixins (more flexible)</small>
+
+    <pre><code>
+      <span class="comment">// Sass (without adding new CSS3 filters)</span>
+      <span class="highlight">.viz--beautiful</span> {
+        @include aden();
+      }
+      <span class="comment">// Sass (adding new CSS3 filters)</span>
+      <span class="highlight">.viz--beautiful</span> {
+        @include aden(blur(2px) /*...*/);
+      }
+    </code></pre>
+
+    <small>Alternatively, you can just download and link any individual .scss file in your Sass manifest: <br> (i.e. <code>scss/aden.scss</code>), if you're just using one of the styles.</li></small>
+
+    <h3>Available Extends</h3>
+    <small><em>For use in Sass elements:</em></small>
+    <ul class="available-classes">
+      <li>1977: <code>@extend %_1977;</code></li>
+      <li>Aden: <code>@extend %aden;</code></li>
+      <li>Brooklyn: <code>@extend %brooklyn;</code></li>
+      <li>Clarendon: <code>@extend %clarendon;</code></li>
+      <li>Earlybird: <code>@extend %earlybird;</code></li>
+      <li>Gingham: <code>@extend %gingham;</code></li>
+      <li>Hudson: <code>@extend %hudson;</code></li>
+      <li>Inkwell: <code>@extend %inkwell;</code></li>
+      <li>Lark: <code>@extend %lark;</code></li>
+      <li>Lo-Fi: <code>@extend %lofi;</code></li>
+      <li>Mayfair: <code>@extend %mayfair;</code></li>
+      <li>Moon: <code>@extend %moon;</code></li>
+      <li>Nashville: <code>@extend %nashville;</code></li>
+      <li>Perpetua: <code>@extend %perpetua;</code></li>
+      <li>Reyes: <code>@extend %reyes;</code></li>
+      <li>Rise: <code>@extend %rise;</code></li>
+      <li>Slumber: <code>@extend %slumber;</code></li>
+      <li>Toaster: <code>@extend %toaster;</code></li>
+      <li>Walden: <code>@extend %walden;</code></li>
+      <li>Willow: <code>@extend %willow;</code></li>
+      <li>X-pro II: <code>@extend %xpro2;</code></li>
+    </ul>
+
+    <h3>Available Mixins</h3>
+
+    <small>
+      <em>For use in Sass elements:</em>
+      <br />
+      <small class="comment">(You can add more CSS3 filters as arguments)</small>
+    </small>
+
+    <ul class="available-classes">
+      <li>1977: <code>@include _1977();</code></li>
+      <li>Aden: <code>@include aden();</code></li>
+      <li>Brooklyn: <code>@include brooklyn();</code></li>
+      <li>Clarendon: <code>@include clarendon();</code></li>
+      <li>Earlybird: <code>@include earlybird();</code></li>
+      <li>Gingham: <code>@include gingham();</code></li>
+      <li>Hudson: <code>@include hudson();</code></li>
+      <li>Inkwell: <code>@include inkwell();</code></li>
+      <li>Lark: <code>@include lark();</code></li>
+      <li>Lo-Fi: <code>@include lofi();</code></li>
+      <li>Mayfair: <code>@include mayfair();</code></li>
+      <li>Moon: <code>@include moon();</code></li>
+      <li>Nashville: <code>@include nashville();</code></li>
+      <li>Perpetua: <code>@include perpetua();</code></li>
+      <li>Reyes: <code>@include reyes();</code></li>
+      <li>Rise: <code>@include rise();</code></li>
+      <li>Slumber: <code>@include slumber();</code></li>
+      <li>Toaster: <code>@include toaster();</code></li>
+      <li>Walden: <code>@include walden();</code></li>
+      <li>Willow: <code>@include willow();</code></li>
+      <li>X-pro II: <code>@include xpro2();</code></li>
+    </ul>
+    <hr>
+  </section>
+
+  <footer class="attribution">Made with love by <a href="http://twitter.com/una">Una</a> | <a href="http://github.com/una/CSSgram">View Source</a></footer>
+
+  <script>
+    var inputField = document.querySelector(".demo__input-img")
+
+    function pickSample(img) {
+      updateImages(img.src)
+      inputField.value = img.getAttribute("src")
+    }
+
     function updateImages(src) {
       var imgs = document.querySelectorAll(".demo__item img")
       for (var i = 0; i < imgs.length; i++) imgs[i].src = src
@@ -341,4 +758,19 @@
     pickSample(document.querySelector(".demo__option-img"))
   </script>
 </body>
+
+</html>    }
+    document.addEventListener("click", function(event) {
+      if (/demo__option-img/.test(event.target.className)) pickSample(event.target)
+    }, false)
+    inputField.addEventListener("input", function() {
+      updateImages(this.value)
+    }, false)
+    inputField.addEventListener("focus", function() {
+      this.select()
+    }, false)
+    pickSample(document.querySelector(".demo__option-img"))
+  </script>
+</body>
+
 </html>

--- a/source/scss/1977.scss
+++ b/source/scss/1977.scss
@@ -4,13 +4,36 @@
  */
 @import 'shared';
 
-%_1977,
-._1977 {
+// mixin to extend 1977 filter
+// @mixin _1977
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include _1977;
+//   }
+//   or
+//   img {
+//     @include _1977(blur(2px));
+//   }
+//   or
+//   img {
+//     @include _1977(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin _1977($filters...) {
   @extend %filter-base;
-  filter: contrast(1.1) brightness(1.1) saturate(1.3);
+  filter: contrast(1.1) brightness(1.1) saturate(1.3) $filters;
 
   &:after{
     background: rgba(243, 106, 188, .3);
     mix-blend-mode: screen;
   }
+  @content;
+}
+
+// 1977 Instagram filter
+%_1977,
+._1977 {
+  @include _1977;
 }

--- a/source/scss/aden.scss
+++ b/source/scss/aden.scss
@@ -6,13 +6,37 @@
 
 @import 'shared';
 
-%aden,
-.aden {
+// mixin to extend aden filter
+// @mixin aden
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include aden;
+//   }
+//   or
+//   img {
+//     @include aden(blur(2px));
+//   }
+//   or
+//   img {
+//     @include aden(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin aden($filters...) {
   @extend %filter-base;
-  filter: hue-rotate(-20deg) contrast(.9) saturate(.85) brightness(1.2);
+  filter: hue-rotate(-20deg) contrast(.9) saturate(.85) brightness(1.2) $filters;
 
   &::after {
     background: linear-gradient(to right, rgba(66, 10, 14, .2), transparent);
     mix-blend-mode: darken;
   }
+
+  @content;
+}
+
+// aden Instagram filter
+%aden,
+.aden {
+  @include aden;
 }

--- a/source/scss/brooklyn.scss
+++ b/source/scss/brooklyn.scss
@@ -5,13 +5,37 @@
  */
 @import 'shared';
 
-%brooklyn,
-.brooklyn {
+// mixin to extend brooklyn filter
+// @mixin brooklyn
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include brooklyn;
+//   }
+//   or
+//   img {
+//     @include brooklyn(blur(2px));
+//   }
+//   or
+//   img {
+//     @include brooklyn(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin brooklyn($filters...) {
   @extend %filter-base;
-  filter: contrast(.9) brightness(1.1);
+  filter: contrast(.9) brightness(1.1) $filters;
 
   &::after {
     background: radial-gradient(circle, rgba(168, 223, 193, .4) 70%, rgb(196, 183, 200));
     mix-blend-mode: overlay;
   }
+
+  @content;
+}
+
+// brooklyn Instagram filter
+%brooklyn,
+.brooklyn {
+  @include brooklyn;
 }

--- a/source/scss/clarendon.scss
+++ b/source/scss/clarendon.scss
@@ -4,13 +4,37 @@
  */
 @import 'shared';
 
-%clarendon,
-.clarendon {
+// mixin to extend clarendon filter
+// @mixin clarendon
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include clarendon;
+//   }
+//   or
+//   img {
+//     @include clarendon(blur(2px));
+//   }
+//   or
+//   img {
+//     @include clarendon(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin clarendon($filters...) {
   @extend %filter-base;
-  filter: contrast(1.2) saturate(1.35);
+  filter: contrast(1.2) saturate(1.35) $filters;
 
   &:before {
     background: rgba(127, 187, 227, .2);
     mix-blend-mode: overlay;
   }
+
+  @content;
+}
+
+// clarendon Instagram filter
+%clarendon,
+.clarendon {
+  @include clarendon;
 }

--- a/source/scss/earlybird.scss
+++ b/source/scss/earlybird.scss
@@ -5,13 +5,37 @@
  */
 @import 'shared';
 
-%earlybird,
-.earlybird {
+// mixin to extend earlybird filter
+// @mixin earlybird
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include earlybird;
+//   }
+//   or
+//   img {
+//     @include earlybird(blur(2px));
+//   }
+//   or
+//   img {
+//     @include earlybird(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin earlybird($filters...) {
   @extend %filter-base;
-  filter: contrast(.9) sepia(.2);
+  filter: contrast(.9) sepia(.2) $filters;
 
   &::after {
     background: radial-gradient(circle, rgb(208, 186, 142) 20%, rgb(54, 3, 9) 85%, rgb(29, 2, 16) 100%);
     mix-blend-mode: overlay;
   }
+
+  @content;
+}
+
+// earlybird Instagram filter
+%earlybird,
+.earlybird {
+  @include earlybird;
 }

--- a/source/scss/gingham.scss
+++ b/source/scss/gingham.scss
@@ -5,13 +5,37 @@
  */
 @import 'shared';
 
-%gingham,
-.gingham {
+// mixin to extend gingham filter
+// @mixin gingham
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include gingham;
+//   }
+//   or
+//   img {
+//     @include gingham(blur(2px));
+//   }
+//   or
+//   img {
+//     @include gingham(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin gingham($filters...) {
   @extend %filter-base;
-  filter: brightness(1.05) hue-rotate(-10deg);
+  filter: brightness(1.05) hue-rotate(-10deg) $filters;
 
   &::after {
     background: linear-gradient(to right, rgba(66, 10, 14, .2), transparent);
     mix-blend-mode: darken;
   }
+
+  @content;
+}
+
+// gingham Instagram filter
+%gingham,
+.gingham {
+  @include gingham;
 }

--- a/source/scss/hudson.scss
+++ b/source/scss/hudson.scss
@@ -5,14 +5,38 @@
  */
 @import 'shared';
 
-%hudson, //needs work!
-.hudson {
+// mixin to extend hudson filter
+// @mixin hudson
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include hudson;
+//   }
+//   or
+//   img {
+//     @include hudson(blur(2px));
+//   }
+//   or
+//   img {
+//     @include hudson(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin hudson($filters...) {
   @extend %filter-base;
-  filter: brightness(1.2) contrast(.9) saturate(1.1);
+  filter: brightness(1.2) contrast(.9) saturate(1.1) $filters;
 
   &::after {
     background: radial-gradient(circle, rgb(166, 177, 255) 50%, rgb(52, 33, 52));
     mix-blend-mode: multiply;
     opacity: .5;
   }
+
+  @content;
+}
+
+// hudson Instagram filter
+%hudson,
+.hudson {
+  @include hudson;
 }

--- a/source/scss/inkwell.scss
+++ b/source/scss/inkwell.scss
@@ -3,9 +3,34 @@
  * Inkwell
  *
  */
+@import 'shared';
 
+// mixin to extend inkwell filter
+// @mixin inkwell
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include inkwell;
+//   }
+//   or
+//   img {
+//     @include inkwell(blur(2px));
+//   }
+//   or
+//   img {
+//     @include inkwell(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin inkwell($filters...) {
+  @extend %filter-base;
+  filter: sepia(.3) contrast(1.1) brightness(1.1) grayscale(1) $filters;
+
+  @content;
+}
+
+// inkwell Instagram filter
 %inkwell,
 .inkwell {
-  @extend %filter-base;
-  filter: sepia(.3) contrast(1.1) brightness(1.1) grayscale(1);
+  @include inkwell;
 }

--- a/source/scss/lark.scss
+++ b/source/scss/lark.scss
@@ -4,10 +4,26 @@
  */
 @import 'shared';
 
-%lark,
-.lark {
+// mixin to extend lark filter
+// @mixin lark
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include lark;
+//   }
+//   or
+//   img {
+//     @include lark(blur(2px));
+//   }
+//   or
+//   img {
+//     @include lark(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin lark($filters...) {
   @extend %filter-base;
-  filter: contrast(.9);
+  filter: contrast(.9) $filters;
 
   &::after {
     background: rgba(242, 242, 242, .8);
@@ -18,4 +34,12 @@
     background: rgb(34, 37, 63);
     mix-blend-mode: color-dodge;
   }
+
+  @content;
+}
+
+// lark Instagram filter
+%lark,
+.lark {
+  @include lark;
 }

--- a/source/scss/lofi.scss
+++ b/source/scss/lofi.scss
@@ -4,13 +4,37 @@
  */
 @import 'shared';
 
-%lofi,
-.lofi {
+// mixin to extend lofi filter
+// @mixin lofi
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include lofi;
+//   }
+//   or
+//   img {
+//     @include lofi(blur(2px));
+//   }
+//   or
+//   img {
+//     @include lofi(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin lofi($filters...) {
   @extend %filter-base;
-  filter: saturate(1.1) contrast(1.5);
+  filter: saturate(1.1) contrast(1.5) $filters;
 
   &::after {
     background: radial-gradient(circle, transparent 70%, rgb(34, 34, 34) 150%);
     mix-blend-mode: multiply;
   }
+
+  @content;
+}
+
+// lofi Instagram filter
+%lofi,
+.lofi {
+  @include lofi;
 }

--- a/source/scss/mayfair.scss
+++ b/source/scss/mayfair.scss
@@ -5,14 +5,38 @@
  */
 @import 'shared';
 
-%mayfair,
-.mayfair {
+// mixin to extend mayfair filter
+// @mixin mayfair
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include mayfair;
+//   }
+//   or
+//   img {
+//     @include mayfair(blur(2px));
+//   }
+//   or
+//   img {
+//     @include mayfair(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin mayfair($filters...) {
   @extend %filter-base;
-  filter: contrast(1.1) saturate(1.1);
+  filter: contrast(1.1) saturate(1.1) $filters;
 
   &::after {
     background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, .8), rgba(255, 200, 200, .6), rgb(17, 17, 17) 60%);
     mix-blend-mode: overlay;
     opacity: .4;
   }
+
+  @content;
+}
+
+// mayfair Instagram filter
+%mayfair,
+.mayfair {
+  @include mayfair;
 }

--- a/source/scss/moon.scss
+++ b/source/scss/moon.scss
@@ -4,10 +4,26 @@
  */
 @import 'shared';
 
-%moon,
-.moon {
+// mixin to extend moon filter
+// @mixin moon
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include moon;
+//   }
+//   or
+//   img {
+//     @include moon(blur(2px));
+//   }
+//   or
+//   img {
+//     @include moon(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin moon($filters...) {
   @extend %filter-base;
-  filter: grayscale(1) contrast(1.1) brightness(1.1);
+  filter: grayscale(1) contrast(1.1) brightness(1.1) $filters;
 
   &::before {
     background: rgb(160, 160, 160);
@@ -18,4 +34,12 @@
     background: rgb(56, 56, 56);
     mix-blend-mode: lighten;
   }
+
+  @content;
+}
+
+// moon Instagram filter
+%moon,
+.moon {
+  @include moon;
 }

--- a/source/scss/nashville.scss
+++ b/source/scss/nashville.scss
@@ -5,10 +5,26 @@
  */
 @import 'shared';
 
-%nashville,
-.nashville {
+// mixin to extend nashville filter
+// @mixin nashville
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include nashville;
+//   }
+//   or
+//   img {
+//     @include nashville(blur(2px));
+//   }
+//   or
+//   img {
+//     @include nashville(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin nashville($filters...) {
   @extend %filter-base;
-  filter: sepia(.2) contrast(1.2) brightness(1.05) saturate(1.2);
+  filter: sepia(.2) contrast(1.2) brightness(1.05) saturate(1.2) $filters;
 
   &::after {
     background: rgba(0, 70, 150, .4);
@@ -19,4 +35,12 @@
     background: rgba(247, 176, 153, .56);
     mix-blend-mode: darken;
   }
+
+  @content;
+}
+
+// nashville Instagram filter
+%nashville,
+.nashville {
+  @include nashville;
 }

--- a/source/scss/perpetua.scss
+++ b/source/scss/perpetua.scss
@@ -5,13 +5,40 @@
  */
 @import 'shared';
 
-%perpetua,
-.perpetua {
+// mixin to extend perpetua filter
+// @mixin perpetua
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include perpetua;
+//   }
+//   or
+//   img {
+//     @include perpetua(blur(2px));
+//   }
+//   or
+//   img {
+//     @include perpetua(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin perpetua($filters...) {
   @extend %filter-base;
+  @if length($filters) > 0 {
+    filter: $filters;
+  }
 
   &::after {
     background: linear-gradient(to bottom, rgb(0, 91, 154), rgb(230, 193, 61));
     mix-blend-mode: soft-light;
     opacity: .5;
   }
+
+  @content;
+}
+
+// perpetua Instagram filter
+%perpetua,
+.perpetua {
+  @include perpetua;
 }

--- a/source/scss/reyes.scss
+++ b/source/scss/reyes.scss
@@ -5,14 +5,38 @@
  */
 @import 'shared';
 
-%reyes,
-.reyes {
+// mixin to extend reyes filter
+// @mixin reyes
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include reyes;
+//   }
+//   or
+//   img {
+//     @include reyes(blur(2px));
+//   }
+//   or
+//   img {
+//     @include reyes(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin reyes($filters...) {
   @extend %filter-base;
-  filter: sepia(.22) brightness(1.1) contrast(.85) saturate(.75);
+  filter: sepia(.22) brightness(1.1) contrast(.85) saturate(.75) $filters;
 
    &::after {
     background: rgb(239, 205, 173);
     mix-blend-mode: soft-light;
     opacity: .5;
   }
+  
+  @content;
+}
+
+// reyes Instagram filter
+%reyes,
+.reyes {
+  @include reyes;
 }

--- a/source/scss/rise.scss
+++ b/source/scss/rise.scss
@@ -5,10 +5,26 @@
  */
 @import 'shared';
 
-%rise,
-.rise {
+// mixin to extend rise filter
+// @mixin rise
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include rise;
+//   }
+//   or
+//   img {
+//     @include rise(blur(2px));
+//   }
+//   or
+//   img {
+//     @include rise(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin rise($filters...) {
   @extend %filter-base;
-  filter: brightness(1.05) sepia(.2) contrast(.9) saturate(.9);
+  filter: brightness(1.05) sepia(.2) contrast(.9) saturate(.9) $filters;
 
   &::after{
     background: radial-gradient(circle, rgba(232, 197, 152, .8), transparent 90%);
@@ -20,4 +36,12 @@
     background: radial-gradient(circle, rgba(236, 205, 169, .15) 55%, rgba(50, 30, 7, .4));
     mix-blend-mode: multiply;
   }
+
+  @content;
+}
+
+// rise Instagram filter
+%rise,
+.rise {
+  @include rise;
 }

--- a/source/scss/slumber.scss
+++ b/source/scss/slumber.scss
@@ -5,10 +5,26 @@
  */
 @import 'shared';
 
-%slumber,
-.slumber {
+// mixin to extend slumber filter
+// @mixin slumber
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include slumber;
+//   }
+//   or
+//   img {
+//     @include slumber(blur(2px));
+//   }
+//   or
+//   img {
+//     @include slumber(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin slumber($filters...) {
   @extend %filter-base;
-  filter: saturate(.66) brightness(1.05);
+  filter: saturate(.66) brightness(1.05) $filters;
 
   &::after {
     background: rgba(125, 105, 24, 0.5);
@@ -19,4 +35,12 @@
     background: rgba(69, 41, 12, .4);
     mix-blend-mode: lighten;
   }
+
+  @content;
+}
+
+// slumber Instagram filter
+%slumber,
+.slumber {
+  @include slumber;
 }

--- a/source/scss/toaster.scss
+++ b/source/scss/toaster.scss
@@ -5,13 +5,37 @@
  */
 @import 'shared';
 
-%toaster,
-.toaster {
+// mixin to extend toaster filter
+// @mixin toaster
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include toaster;
+//   }
+//   or
+//   img {
+//     @include toaster(blur(2px));
+//   }
+//   or
+//   img {
+//     @include toaster(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin toaster($filters...) {
   @extend %filter-base;
-  filter: contrast(1.5) brightness(.9);
+  filter: contrast(1.5) brightness(.9) $filters;
 
   &::after {
     background: radial-gradient(circle, rgb(128, 78, 15), rgb(59, 0, 59));
     mix-blend-mode: screen;
   }
+
+  @content;
+}
+
+// toaster Instagram filter
+%toaster,
+.toaster {
+  @include toaster;
 }

--- a/source/scss/walden.scss
+++ b/source/scss/walden.scss
@@ -5,14 +5,38 @@
  */
 @import 'shared';
 
-%walden,
-.walden {
+// mixin to extend walden filter
+// @mixin walden
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include walden;
+//   }
+//   or
+//   img {
+//     @include walden(blur(2px));
+//   }
+//   or
+//   img {
+//     @include walden(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin walden($filters...) {
   @extend %filter-base;
-  filter: brightness(1.1) hue-rotate(-10deg) sepia(.3) saturate(1.6);
+  filter: brightness(1.1) hue-rotate(-10deg) sepia(.3) saturate(1.6) $filters;
 
   &::after {
     background: rgb(0, 68, 204);
     mix-blend-mode: screen;
     opacity: .3;
   }
+
+  @content;
+}
+
+// walden Instagram filter
+%walden,
+.walden {
+  @include walden;
 }

--- a/source/scss/willow.scss
+++ b/source/scss/willow.scss
@@ -4,10 +4,26 @@
  */
 @import 'shared';
 
-%willow,
-.willow {
+// mixin to extend willow filter
+// @mixin willow
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include willow;
+//   }
+//   or
+//   img {
+//     @include willow(blur(2px));
+//   }
+//   or
+//   img {
+//     @include willow(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin willow($filters...) {
   @extend %filter-base;
-  filter: grayscale(.5) contrast(.95) brightness(.9);
+  filter: grayscale(.5) contrast(.95) brightness(.9) $filters;
 
   &::before {
     background-color: radial-gradient(40%, circle, rgb(212, 169, 175) 55%, black 150%);
@@ -18,4 +34,12 @@
     background-color: rgb(216, 205, 203);
     mix-blend-mode: color;
   }
+
+  @content;
+}
+
+// willow Instagram filter
+%willow,
+.willow {
+  @include willow;
 }

--- a/source/scss/xpro2.scss
+++ b/source/scss/xpro2.scss
@@ -5,13 +5,37 @@
  */
 @import 'shared';
 
-%xpro2,
-.xpro2 {
+// mixin to extend xpro2 filter
+// @mixin xpro2
+// @param $filters... {filter} - Zero to many css filters to be added
+// @example
+//   img {
+//     @include xpro2;
+//   }
+//   or
+//   img {
+//     @include xpro2(blur(2px));
+//   }
+//   or
+//   img {
+//     @include xpro2(blur(2px)) {
+//       /*...*/
+//     };
+//   }
+@mixin xpro2($filters...) {
   @extend %filter-base;
-  filter: sepia(.3);
+  filter: sepia(.3) $filters;
 
   &::after {
     background: radial-gradient(circle, rgb(230, 231, 224) 40%, rgba(43, 42, 161, .6) 110%);
     mix-blend-mode: color-burn;
   }
+
+  @content;
+}
+
+// xpro2 Instagram filter
+%xpro2,
+.xpro2 {
+  @include xpro2;
 }


### PR DESCRIPTION
**Q: What this PR fixes?**
**A:** Allows add filter to an existing CSSgram filter (only using SASS)

**Q: Why?**
**A:** CSS3 filter property does not allow inheritance, you cannot 'add' new filters keeping the existing filters

Before:
```
figure {
  @extend %aden;
  &:hover{
    filter: blur(2px); // overrides Aden filter, now has only blur filter
  }
}
```

Now:
```
figure {
  @extend %aden; // or @include aden;
  &:hover{
    @include aden(blur(2px) /*...*/); // Aden filter still works, but now blur filter was 'added'
  }
}
```

_PS: Now comments are compatible with SassDoc._

:smile: