### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+dist: trusty
+
+language: node_js
+node_js:
+  - "4"
+  - "5"
+  - "6"
+
+before_script:
+  - npm install -g gulp
+
+script:
+  - gulp lib-scss
+  - gulp sass-lint


### PR DESCRIPTION
Hey @una!

I took the liberty to add a .travis.yml mentioned in this issue https://github.com/una/CSSgram/issues/168

The current configuration runs `gulp lib-scss` and `gulp sass-lint` on Node versions 4, 5 and 6.
Let me know if you need these configurations changed. 

I'd also add a Gulp task that builds the site but doesn't use browser sync/ opens a browser. wdyt?