### PR TITLE
css reload fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,12 +36,12 @@ gulp.task('lib-scss', function() {
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(prefix())
     .pipe(gulp.dest('source/css'))
-    .pipe(reload({stream:true}))
     .pipe(cssmin())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(rename({ suffix: '.min' }))
     .pipe(gulp.dest('source/css'))
-    .pipe(gulp.dest('site/css'));
+    .pipe(gulp.dest('site/css'))
+    .pipe(reload({stream:true}));
 });
 
 gulp.task('site-scss', function() {
@@ -61,11 +61,11 @@ gulp.task('site-scss', function() {
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(prefix())
     .pipe(gulp.dest('site/css'))
-    .pipe(reload({stream:true}))
     .pipe(cssmin())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(rename({ suffix: '.min' }))
-    .pipe(gulp.dest('site/css'));
+    .pipe(gulp.dest('site/css'))
+    .pipe(reload({stream:true}));
 });
 
 gulp.task('browser-sync', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('twig', function () {
 
 
 gulp.task('watch', function() {
-  gulp.watch('source/scss/**/*.scss', ['lib-scss', 'sass-lint']);
+  gulp.watch('source/scss/**/*.scss', ['lib-scss', 'site-scss', 'sass-lint']);
   gulp.watch('site/scss/**/*.scss', ['site-scss', 'sass-lint']);
   gulp.watch('source/scss/**/*.html', ['minify-html']);
   gulp.watch('site/**/*.twig', ['twig']);


### PR DESCRIPTION
1. The `browserSync.reload` is currently placed before `cssmin`. Since the site uses minified css, scss changes are not getting reflected there. So **reload pipe moved after min**.
2. `demo-site.scss` does `@import 'source/scss/cssgram'`, but changes in source scss doesn't get updated in site scss instantly. So **added `site-scss` to `lib-scss` watch**.